### PR TITLE
Configure next/image hostname

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
   staticPageGenerationTimeout: 1000,
   images: {
     unoptimized: true, // for cloudflare pages
-    domains: ['gola-nft-marketplace.infura-ipfs.io','gateway.pinata.cloud']
+    domains: ['gola-nft-marketplace.infura-ipfs.io','gateway.pinata.cloud','copper-zippy-woodpecker-824.mypinata.cloud']
   },
   compiler: {
     styledComponents: true


### PR DESCRIPTION
Add `copper-zippy-woodpecker-824.mypinata.cloud` to `next.config.js` to resolve the `next/image` unconfigured host error for Pinata gateway images.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2deaf33-f436-4de0-8288-32e13ed114b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c2deaf33-f436-4de0-8288-32e13ed114b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

