### PR TITLE
Fix missing image src property

### DIFF
--- a/pages/my-nfts.js
+++ b/pages/my-nfts.js
@@ -75,7 +75,7 @@ const MyNFTs = () => {
         />
         <div className="flexCenter flex-col -mt-20 z-0">
           <div className="flexCenter w-40 h-40 sm:w-36 sm:h-36 p-1 bg-nft-black-2 rounded-full">
-            <Image src={images.creator1} className="rounded-full object-cover" objectFit="cover" />
+            <Image src={images.creator1} layout="fill" className="rounded-full object-cover" objectFit="cover" />
           </div>
           <p className="font-poppins dark:text-white text-nft-black-1 font-semibold text-2xl mt-6">{shortenAddress(currentAccount)}</p>
         </div>

--- a/pages/nft-details.js
+++ b/pages/nft-details.js
@@ -81,7 +81,7 @@ const NFTDetails = () => {
           <p className="font-poppins dark:text-white text-nft-black-1 text-xs minlg:text-base font-normal">Creator</p>
           <div className="flex flex-row items-center mt-3">
             <div className="relative w-12 h-12 minlg:w-20 minlg:h-20 mr-2">
-              <Image src={images.creator1} objectFit="cover" className="rounded-full" />
+              <Image src={images.creator1} layout="fill" objectFit="cover" className="rounded-full" />
             </div>
             <p className="font-poppins dark:text-white text-nft-black-1 text-xs minlg:text-base font-semibold">{shortenAddress(nft.seller)}</p>
           </div>


### PR DESCRIPTION
Add `layout="fill"` to `next/image` components to resolve a runtime error.

The `next/image` component requires either explicit `width` and `height` props or a `layout` prop (e.g., `layout="fill"`) when used inside a container with defined dimensions. The original error message `Image is missing required "src" property` was misleading; the actual issue was the absence of the `layout` prop.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b3b975e-a86e-43b3-8b60-971c3e81348e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b3b975e-a86e-43b3-8b60-971c3e81348e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

