### PR TITLE
Fix missing image src property

### DIFF
--- a/components/Loader.jsx
+++ b/components/Loader.jsx
@@ -4,7 +4,7 @@ import images from '../assets';
 
 const Loader = () => (
   <div className="flexCenter w-full my-4">
-    <Image src={images.loader} alt="loader" width={100} objectFit="contain" />
+    <Image src={images.loader} alt="loader" width={100} height={100} objectFit="contain" />
   </div>
 );
 

--- a/pages/nft-details.js
+++ b/pages/nft-details.js
@@ -81,7 +81,7 @@ const NFTDetails = () => {
           <p className="font-poppins dark:text-white text-nft-black-1 text-xs minlg:text-base font-normal">Creator</p>
           <div className="flex flex-row items-center mt-3">
             <div className="relative w-12 h-12 minlg:w-20 minlg:h-20 mr-2">
-              <Image src={images.creator1} objectFit="cover" className="rounded-full" />
+              <Image src={images.creator1} objectFit="cover" className="rounded-full" layout="fill" />
             </div>
             <p className="font-poppins dark:text-white text-nft-black-1 text-xs minlg:text-base font-semibold">{shortenAddress(nft.seller)}</p>
           </div>


### PR DESCRIPTION
Add missing `height` and `layout` properties to `next/image` components to resolve a runtime error.

The initial error message indicated a missing `src` property, but the underlying cause was the absence of `height` (when `width` was present) and `layout` (when `width`/`height` were not explicitly set alongside `objectFit`), which are necessary for Next.js to determine image dimensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-730482fb-2bb0-40a9-ba2d-d8ebb689bcd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-730482fb-2bb0-40a9-ba2d-d8ebb689bcd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

