### PR TITLE
Fix missing image src property

### DIFF
--- a/pages/my-nfts.js
+++ b/pages/my-nfts.js
@@ -75,7 +75,7 @@ const MyNFTs = () => {
         />
         <div className="flexCenter flex-col -mt-20 z-0">
           <div className="flexCenter w-40 h-40 sm:w-36 sm:h-36 p-1 bg-nft-black-2 rounded-full">
-            <Image src={images.creator1} className="rounded-full object-cover" objectFit="cover" />
+            <Image src={images.creator1} className="rounded-full object-cover" objectFit="cover" layout="fill" />
           </div>
           <p className="font-poppins dark:text-white text-nft-black-1 font-semibold text-2xl mt-6">{shortenAddress(currentAccount)}</p>
         </div>

--- a/pages/nft-details.js
+++ b/pages/nft-details.js
@@ -16,7 +16,7 @@ const PaymentBodyCmp = ({ nft, nftCurrency }) => (
     <div className="flexBetweenStart my-5">
       <div className="flex-1 flexStartCenter">
         <div className="relative w-28 h-28">
-          <Image src={nft.image} layout="fill" objectFit="cover" />
+          {nft.image && <Image src={nft.image} layout="fill" objectFit="cover" />}
         </div>
         <div className="flexCenterStart flex-col ml-5">
           <p className="font-poppins dark:text-white text-nft-black-1 font-semibold text-sm minlg:text-xl">{shortenAddress(nft.seller)}</p>
@@ -69,7 +69,7 @@ const NFTDetails = () => {
     <div className="relative flex justify-center md:flex-col min-h-screen">
       <div className="relative flex-1 flexCenter sm:px-4 p-12 border-r md:border-r-0 md:border-b dark:border-nft-black-1 border-nft-gray-1">
         <div className="relative w-557 minmd:w-2/3 minmd:h-2/3 sm:w-full sm:h-300 h-557">
-          <Image src={nft.image} objectFit="cover" className="rounded-xl shadow-lg" layout="fill" />
+          {nft.image && <Image src={nft.image} objectFit="cover" className="rounded-xl shadow-lg" layout="fill" />}
         </div>
       </div>
 
@@ -81,7 +81,7 @@ const NFTDetails = () => {
           <p className="font-poppins dark:text-white text-nft-black-1 text-xs minlg:text-base font-normal">Creator</p>
           <div className="flex flex-row items-center mt-3">
             <div className="relative w-12 h-12 minlg:w-20 minlg:h-20 mr-2">
-              <Image src={images.creator1} objectFit="cover" className="rounded-full" />
+              <Image src={images.creator1} objectFit="cover" className="rounded-full" layout="fill" />
             </div>
             <p className="font-poppins dark:text-white text-nft-black-1 text-xs minlg:text-base font-semibold">{shortenAddress(nft.seller)}</p>
           </div>
@@ -159,7 +159,7 @@ const NFTDetails = () => {
           body={(
             <div className="flexCenter flex-col text-center" onClick={() => setSuccessModal(false)}>
               <div className="relative w-52 h-52">
-                <Image src={nft.image} layout="fill" objectFit="cover" />
+                {nft.image && <Image src={nft.image} layout="fill" objectFit="cover" />}
               </div>
               <p className="font-poppins dark:text-white text-nft-black-1 font-normal text-sm minlg:text-xl mt-10">
                 You successfully purchased <span className="font-semibold">{nft.name}</span> from <span className="font-semibold">{shortenAddress(nft.seller)}</span>.


### PR DESCRIPTION
Fixes "Image is missing required src property" error by adding missing `layout` props and conditionally rendering `next/image` components only when `src` is available.

The error was caused by `next/image` components missing the `layout="fill"` prop and attempting to render with an empty `src` value during initial page load before NFT data was fully populated. Conditional rendering now prevents rendering the image component until a valid `src` is present.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2a1796a-3cbb-47ec-a556-e75224b359ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2a1796a-3cbb-47ec-a556-e75224b359ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

